### PR TITLE
Convert `urlEncodedStringWithEncoding` to use CoreFoundation.

### DIFF
--- a/OAuthSwift/String+OAuthSwift.swift
+++ b/OAuthSwift/String+OAuthSwift.swift
@@ -32,10 +32,7 @@ extension String {
     }
 
     func urlEncodedStringWithEncoding(encoding: NSStringEncoding) -> String {
-        let originalString: NSString = self
-        let customAllowedSet =  NSCharacterSet(charactersInString:" :/?&=;+!@#$()',*=\"#%/<>?@\\^`{|}[]").invertedSet
-        let escapedString = originalString.stringByAddingPercentEncodingWithAllowedCharacters(customAllowedSet)
-        return escapedString! as String
+        return CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, self, nil, "!*'\"();:@&=+$,/?%#[] ", CFStringBuiltInEncodings.UTF8.rawValue) as String
     }
 
     func parametersFromQueryString() -> Dictionary<String, String> {


### PR DESCRIPTION
Utilize `CFURLCreateStringByAddingPercentEscapes` for the percent escaping.
